### PR TITLE
Add resources for codes, UDFs, flags, and metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "betterworldcollective/donorperfect-php-sdk",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "require": {
         "php": "^8.2",
         "saloonphp/saloon": "^4.0",

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -7,6 +7,10 @@ use DonorPerfect\Requests\CallSqlRequest;
 use DonorPerfect\Requests\Donor\SaveDonor;
 use DonorPerfect\Requests\Gift\SaveGift;
 use DonorPerfect\Requests\TestConnection;
+use DonorPerfect\Resources\CodeResource;
+use DonorPerfect\Resources\FlagResource;
+use DonorPerfect\Resources\MetadataResource;
+use DonorPerfect\Resources\UdfResource;
 use DonorPerfect\Responses\DonorPerfectResponse;
 use Exception;
 use Saloon\Contracts\Authenticator;
@@ -126,6 +130,38 @@ class DonorPerfect extends Connector
         } catch (Exception $e) {
             return false;
         }
+    }
+
+    /**
+     * Read dpcodes rows for a given field_name (CAMPAIGN, GL_CODE, etc.).
+     */
+    public function codes(): CodeResource
+    {
+        return new CodeResource($this);
+    }
+
+    /**
+     * Write a UDF value to a donor or gift via dp_save_udf_xml.
+     */
+    public function udfs(): UdfResource
+    {
+        return new UdfResource($this);
+    }
+
+    /**
+     * Apply a flag to a donor via dp_saveflag_xml (additive only).
+     */
+    public function flags(): FlagResource
+    {
+        return new FlagResource($this);
+    }
+
+    /**
+     * Read DPFIELDS metadata describing the org's UDF definitions.
+     */
+    public function metadata(): MetadataResource
+    {
+        return new MetadataResource($this);
     }
 
     /**

--- a/src/Requests/Flag/SaveFlag.php
+++ b/src/Requests/Flag/SaveFlag.php
@@ -1,22 +1,20 @@
 <?php
 
-namespace DonorPerfect\Requests\Donor;
+namespace DonorPerfect\Requests\Flag;
 
 use DonorPerfect\Support\ActionParams;
-use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
-use Saloon\Traits\Body\HasXmlBody;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
 
-class SaveDonor extends Request implements HasBody
+class SaveFlag extends Request
 {
-    use AlwaysThrowOnErrors, HasXmlBody;
+    use AlwaysThrowOnErrors;
 
     protected Method $method = Method::POST;
 
     /**
-     * @param  array<string, mixed>  $properties
+     * @param  array<string, mixed>  $properties  DP @-prefixed param keys (matching_id, flag, optional flag_date)
      */
     public function __construct(protected array $properties) {}
 
@@ -25,18 +23,14 @@ class SaveDonor extends Request implements HasBody
         return '/xmlrequest.asp';
     }
 
+    /**
+     * @return array<string, string>
+     */
     protected function defaultQuery(): array
     {
         return [
-            'action' => 'dp_savedonor',
+            'action' => 'dp_saveflag_xml',
             'params' => ActionParams::serialize($this->properties),
-        ];
-    }
-
-    protected function defaultHeaders(): array
-    {
-        return [
-            'Content-Type' => 'application/x-www-form-urlencoded',
         ];
     }
 }

--- a/src/Requests/Gift/SaveGift.php
+++ b/src/Requests/Gift/SaveGift.php
@@ -2,6 +2,7 @@
 
 namespace DonorPerfect\Requests\Gift;
 
+use DonorPerfect\Support\ActionParams;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -15,7 +16,7 @@ class SaveGift extends Request implements HasBody
     protected Method $method = Method::POST;
 
     /**
-     * @param array<string, mixed> $properties
+     * @param  array<string, mixed>  $properties
      */
     public function __construct(protected array $properties) {}
 
@@ -26,21 +27,9 @@ class SaveGift extends Request implements HasBody
 
     protected function defaultQuery(): array
     {
-        // Build the params string with @ prefix and proper formatting
-        $params = [];
-        foreach ($this->properties as $key => $value) {
-            if ($value === null) {
-                $params[] = "@{$key}=null";
-            } elseif (is_numeric($value)) {
-                $params[] = "@{$key}={$value}";
-            } else {
-                $params[] = "@{$key}='{$value}'";
-            }
-        }
-        
         return [
             'action' => 'dp_savegift',
-            'params' => implode(', ', $params),
+            'params' => ActionParams::serialize($this->properties),
         ];
     }
 

--- a/src/Requests/Udf/SaveUdf.php
+++ b/src/Requests/Udf/SaveUdf.php
@@ -1,22 +1,20 @@
 <?php
 
-namespace DonorPerfect\Requests\Donor;
+namespace DonorPerfect\Requests\Udf;
 
 use DonorPerfect\Support\ActionParams;
-use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
-use Saloon\Traits\Body\HasXmlBody;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
 
-class SaveDonor extends Request implements HasBody
+class SaveUdf extends Request
 {
-    use AlwaysThrowOnErrors, HasXmlBody;
+    use AlwaysThrowOnErrors;
 
     protected Method $method = Method::POST;
 
     /**
-     * @param  array<string, mixed>  $properties
+     * @param  array<string, mixed>  $properties  DP @-prefixed param keys (matching_id, field_name, data_type, field_value)
      */
     public function __construct(protected array $properties) {}
 
@@ -25,18 +23,14 @@ class SaveDonor extends Request implements HasBody
         return '/xmlrequest.asp';
     }
 
+    /**
+     * @return array<string, string>
+     */
     protected function defaultQuery(): array
     {
         return [
-            'action' => 'dp_savedonor',
+            'action' => 'dp_save_udf_xml',
             'params' => ActionParams::serialize($this->properties),
-        ];
-    }
-
-    protected function defaultHeaders(): array
-    {
-        return [
-            'Content-Type' => 'application/x-www-form-urlencoded',
         ];
     }
 }

--- a/src/Resources/CodeResource.php
+++ b/src/Resources/CodeResource.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DonorPerfect\Resources;
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\InvalidDataException;
+use DonorPerfect\Requests\CallSqlRequest;
+use Saloon\Http\BaseResource;
+use SimpleXMLElement;
+
+class CodeResource extends BaseResource
+{
+    private const ALLOWED_FIELD_NAMES = [
+        'CAMPAIGN',
+        'GL_CODE',
+        'SOLICIT',
+        'EMAIL_TYPE',
+        'PHONE_TYPE',
+        'ADDRESS_TYPE',
+    ];
+
+    /**
+     * Fetch dpcodes rows for the given DP field_name.
+     *
+     * Allowed field names mirror the BB-parity dropdowns; the allowlist defends
+     * against SQL injection even though the value is internal.
+     *
+     * @return array<int, array{code: string, description: ?string, inactive: bool}>
+     *
+     * @throws InvalidDataException when $fieldName is not in the allowlist
+     */
+    public function list(string $fieldName): array
+    {
+        if (! in_array($fieldName, self::ALLOWED_FIELD_NAMES, true)) {
+            throw new InvalidDataException("Unsupported dpcodes field_name: {$fieldName}");
+        }
+
+        $connector = $this->connector;
+        assert($connector instanceof DonorPerfect);
+
+        $sql = "SELECT CODE, DESCRIPTION, INACTIVE FROM dpcodes WHERE FIELD_NAME = '{$fieldName}'";
+        $response = $connector->send(new CallSqlRequest($sql));
+
+        $xml = $response->xml();
+
+        if (! $xml instanceof SimpleXMLElement || ! isset($xml->record)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($xml->record as $record) {
+            $rows[] = $this->normalizeRecord($record);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array{code: string, description: ?string, inactive: bool}
+     */
+    private function normalizeRecord(SimpleXMLElement $record): array
+    {
+        $row = ['code' => '', 'description' => null, 'inactive' => false];
+
+        foreach ($record->field ?? [] as $field) {
+            $name = (string) ($field['name'] ?? '');
+            $value = (string) ($field['value'] ?? '');
+
+            switch ($name) {
+                case 'CODE':
+                    $row['code'] = $value;
+                    break;
+                case 'DESCRIPTION':
+                    $row['description'] = $value === '' ? null : $value;
+                    break;
+                case 'INACTIVE':
+                    $row['inactive'] = $value === '1' || strcasecmp($value, 'true') === 0;
+                    break;
+            }
+        }
+
+        return $row;
+    }
+}

--- a/src/Resources/FlagResource.php
+++ b/src/Resources/FlagResource.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DonorPerfect\Resources;
+
+use DateTimeInterface;
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Requests\Flag\SaveFlag;
+use Saloon\Http\BaseResource;
+
+class FlagResource extends BaseResource
+{
+    /**
+     * Apply a flag to a donor. Additive — never deletes existing flags.
+     *
+     * Use the additive `dp_saveflag_xml` action exclusively. The DP-side
+     * `dp_delflags_xml` wipes ALL flags for a donor and is intentionally NOT
+     * exposed by this SDK to prevent accidental data loss in sync listeners.
+     *
+     * @return array<string, mixed>
+     */
+    public function save(int $donorId, string $flagCode, ?DateTimeInterface $flagDate = null): array
+    {
+        $connector = $this->connector;
+        assert($connector instanceof DonorPerfect);
+
+        $properties = [
+            'matching_id' => $donorId,
+            'flag' => $flagCode,
+        ];
+
+        if ($flagDate !== null) {
+            $properties['flag_date'] = $flagDate->format('Y-m-d');
+        }
+
+        $response = $connector->send(new SaveFlag($properties));
+
+        return $response->xmlArray();
+    }
+}

--- a/src/Resources/MetadataResource.php
+++ b/src/Resources/MetadataResource.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DonorPerfect\Resources;
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\InvalidDataException;
+use DonorPerfect\Requests\CallSqlRequest;
+use Saloon\Http\BaseResource;
+use SimpleXMLElement;
+
+class MetadataResource extends BaseResource
+{
+    private const ALLOWED_TABLE_NAMES = ['DP', 'DPGIFT', 'PLEDGE'];
+
+    /**
+     * Read DPFIELDS rows describing the org's UDFs.
+     *
+     * @param  list<string>  $tableNames  defaults to donor + gift UDFs
+     * @return array<int, array{table_name: string, field_name: string, prompt: ?string, data_type: string}>
+     *
+     * @throws InvalidDataException when any $tableNames entry is not in the allowlist
+     */
+    public function list(array $tableNames = ['DP', 'DPGIFT']): array
+    {
+        if ($tableNames === []) {
+            throw new InvalidDataException('At least one DPFIELDS TABLE_NAME is required');
+        }
+
+        foreach ($tableNames as $tableName) {
+            if (! in_array($tableName, self::ALLOWED_TABLE_NAMES, true)) {
+                throw new InvalidDataException("Unsupported DPFIELDS table_name: {$tableName}");
+            }
+        }
+
+        $connector = $this->connector;
+        assert($connector instanceof DonorPerfect);
+
+        $inList = "'".implode("','", $tableNames)."'";
+        $sql = "SELECT TABLE_NAME, FIELD_NAME, PROMPT, DATA_TYPE FROM DPFIELDS WHERE TABLE_NAME IN ({$inList})";
+
+        $response = $connector->send(new CallSqlRequest($sql));
+        $xml = $response->xml();
+
+        if (! $xml instanceof SimpleXMLElement || ! isset($xml->record)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($xml->record as $record) {
+            $rows[] = $this->normalizeRecord($record);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array{table_name: string, field_name: string, prompt: ?string, data_type: string}
+     */
+    private function normalizeRecord(SimpleXMLElement $record): array
+    {
+        $row = ['table_name' => '', 'field_name' => '', 'prompt' => null, 'data_type' => ''];
+
+        foreach ($record->field ?? [] as $field) {
+            $name = (string) ($field['name'] ?? '');
+            $value = (string) ($field['value'] ?? '');
+
+            switch ($name) {
+                case 'TABLE_NAME':
+                    $row['table_name'] = $value;
+                    break;
+                case 'FIELD_NAME':
+                    $row['field_name'] = $value;
+                    break;
+                case 'PROMPT':
+                    $row['prompt'] = $value === '' ? null : $value;
+                    break;
+                case 'DATA_TYPE':
+                    $row['data_type'] = $value;
+                    break;
+            }
+        }
+
+        return $row;
+    }
+}

--- a/src/Resources/UdfResource.php
+++ b/src/Resources/UdfResource.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DonorPerfect\Resources;
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\InvalidDataException;
+use DonorPerfect\Requests\Udf\SaveUdf;
+use Saloon\Http\BaseResource;
+
+class UdfResource extends BaseResource
+{
+    private const ALLOWED_DATA_TYPES = ['C', 'D', 'M', 'N'];
+
+    /**
+     * Write a single UDF value to a DonorPerfect record (donor or gift).
+     *
+     * $matchingId is donor_id when the UDF lives on the DP table, or gift_id
+     * when on DPGIFT — DP routes by data_type + the UDF's own table.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws InvalidDataException when $dataType is not one of C/D/M/N
+     */
+    public function save(int $matchingId, string $fieldName, string $dataType, ?string $value): array
+    {
+        if (! in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
+            throw new InvalidDataException("Unsupported DPFIELDS data_type: {$dataType}");
+        }
+
+        $connector = $this->connector;
+        assert($connector instanceof DonorPerfect);
+
+        $response = $connector->send(new SaveUdf([
+            'matching_id' => $matchingId,
+            'field_name' => $fieldName,
+            'data_type' => $dataType,
+            'field_value' => $value,
+        ]));
+
+        return $response->xmlArray();
+    }
+}

--- a/src/Support/ActionParams.php
+++ b/src/Support/ActionParams.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DonorPerfect\Support;
+
+/**
+ * Serializes a property bag into DP's `@key=value` action-param format.
+ *
+ * Used by every request class that calls a `dp_*_xml` action endpoint
+ * (SaveDonor, SaveGift, SaveUdf, SaveFlag). DP expects strings to be
+ * single-quoted, numerics bare, and nulls as the bare token `null`.
+ */
+final class ActionParams
+{
+    /**
+     * @param  array<string, mixed>  $properties
+     */
+    public static function serialize(array $properties): string
+    {
+        $params = [];
+        foreach ($properties as $key => $value) {
+            if ($value === null) {
+                $params[] = "@{$key}=null";
+            } elseif (is_numeric($value)) {
+                $params[] = "@{$key}={$value}";
+            } else {
+                $params[] = "@{$key}='{$value}'";
+            }
+        }
+
+        return implode(', ', $params);
+    }
+}

--- a/tests/Unit/Resources/CodeResourceTest.php
+++ b/tests/Unit/Resources/CodeResourceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\InvalidDataException;
+use DonorPerfect\Requests\CallSqlRequest;
+use DonorPerfect\Resources\CodeResource;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('exposes a codes() accessor on the connector', function () {
+    $connector = new DonorPerfect('test-api-key');
+
+    expect($connector->codes())->toBeInstanceOf(CodeResource::class);
+});
+
+it('builds a dpcodes SELECT for a valid field_name and hits /xmlrequest.asp', function () {
+    $mockClient = new MockClient([
+        CallSqlRequest::class => MockResponse::make(
+            <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <result>
+                <record>
+                    <field name="CODE" value="GENERAL"/>
+                    <field name="DESCRIPTION" value="General Fund"/>
+                    <field name="INACTIVE" value="0"/>
+                </record>
+                <record>
+                    <field name="CODE" value="LEGACY"/>
+                    <field name="DESCRIPTION" value="Legacy Fund"/>
+                    <field name="INACTIVE" value="1"/>
+                </record>
+            </result>
+            XML
+        ),
+    ]);
+
+    $connector = new DonorPerfect('test-api-key');
+    $connector->withMockClient($mockClient);
+
+    $rows = $connector->codes()->list('CAMPAIGN');
+
+    $mockClient->assertSent(function (CallSqlRequest $request): bool {
+        $sql = $request->query()->get('action');
+
+        return $request->resolveEndpoint() === '/xmlrequest.asp'
+            && $sql === "SELECT CODE, DESCRIPTION, INACTIVE FROM dpcodes WHERE FIELD_NAME = 'CAMPAIGN'";
+    });
+
+    expect($rows)->toHaveCount(2)
+        ->and($rows[0])->toMatchArray([
+            'code' => 'GENERAL',
+            'description' => 'General Fund',
+            'inactive' => false,
+        ])
+        ->and($rows[1])->toMatchArray([
+            'code' => 'LEGACY',
+            'description' => 'Legacy Fund',
+            'inactive' => true,
+        ]);
+});
+
+it('returns an empty array when DP returns no records', function () {
+    $mockClient = new MockClient([
+        CallSqlRequest::class => MockResponse::make(
+            '<?xml version="1.0" encoding="UTF-8"?><result/>'
+        ),
+    ]);
+
+    $connector = new DonorPerfect('test-api-key');
+    $connector->withMockClient($mockClient);
+
+    expect($connector->codes()->list('GL_CODE'))->toBe([]);
+});
+
+it('throws InvalidDataException for an unknown field_name', function () {
+    $connector = new DonorPerfect('test-api-key');
+
+    $connector->codes()->list("CAMPAIGN'; DROP TABLE dpcodes; --");
+})->throws(InvalidDataException::class);
+
+it('accepts every BB-parity field_name', function (string $fieldName) {
+    $mockClient = new MockClient([
+        CallSqlRequest::class => MockResponse::make(
+            '<?xml version="1.0" encoding="UTF-8"?><result/>'
+        ),
+    ]);
+
+    $connector = new DonorPerfect('test-api-key');
+    $connector->withMockClient($mockClient);
+
+    expect($connector->codes()->list($fieldName))->toBe([]);
+})->with([
+    'CAMPAIGN',
+    'GL_CODE',
+    'SOLICIT',
+    'EMAIL_TYPE',
+    'PHONE_TYPE',
+    'ADDRESS_TYPE',
+]);

--- a/tests/Unit/Resources/FlagResourceTest.php
+++ b/tests/Unit/Resources/FlagResourceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Requests\Flag\SaveFlag;
+use DonorPerfect\Resources\FlagResource;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('exposes a flags() accessor on the connector', function () {
+    expect((new DonorPerfect('k'))->flags())->toBeInstanceOf(FlagResource::class);
+});
+
+it('builds a dp_saveflag_xml call with @matching_id and @flag', function () {
+    $mockClient = new MockClient([
+        SaveFlag::class => MockResponse::make('<?xml version="1.0"?><result><record><field name="success" value="true"/></record></result>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->flags()->save(donorId: 9876, flagCode: 'WEB');
+
+    $mockClient->assertSent(function (SaveFlag $request): bool {
+        return $request->query()->get('action') === 'dp_saveflag_xml'
+            && str_contains($request->query()->get('params'), '@matching_id=9876')
+            && str_contains($request->query()->get('params'), "@flag='WEB'");
+    });
+});
+
+it('passes @flag_date when one is provided', function () {
+    $mockClient = new MockClient([
+        SaveFlag::class => MockResponse::make('<?xml version="1.0"?><result/>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->flags()->save(1, 'WEB', new DateTimeImmutable('2026-05-05'));
+
+    $mockClient->assertSent(function (SaveFlag $request): bool {
+        return str_contains($request->query()->get('params'), "@flag_date='2026-05-05'");
+    });
+});
+
+it('omits @flag_date when none is provided so DP defaults to today', function () {
+    $mockClient = new MockClient([
+        SaveFlag::class => MockResponse::make('<?xml version="1.0"?><result/>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->flags()->save(1, 'WEB');
+
+    $mockClient->assertSent(function (SaveFlag $request): bool {
+        return ! str_contains($request->query()->get('params'), '@flag_date');
+    });
+});

--- a/tests/Unit/Resources/MetadataResourceTest.php
+++ b/tests/Unit/Resources/MetadataResourceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\InvalidDataException;
+use DonorPerfect\Requests\CallSqlRequest;
+use DonorPerfect\Resources\MetadataResource;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('exposes a metadata() accessor on the connector', function () {
+    expect((new DonorPerfect('k'))->metadata())->toBeInstanceOf(MetadataResource::class);
+});
+
+it('reads DPFIELDS for DP and DPGIFT by default and parses each row', function () {
+    $mockClient = new MockClient([
+        CallSqlRequest::class => MockResponse::make(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <result>
+                <record>
+                    <field name="TABLE_NAME" value="DP"/>
+                    <field name="FIELD_NAME" value="PRONOUN_UDF"/>
+                    <field name="PROMPT" value="Pronoun"/>
+                    <field name="DATA_TYPE" value="C"/>
+                </record>
+                <record>
+                    <field name="TABLE_NAME" value="DPGIFT"/>
+                    <field name="FIELD_NAME" value="SOURCE_UDF"/>
+                    <field name="PROMPT" value="Campaign Source"/>
+                    <field name="DATA_TYPE" value="C"/>
+                </record>
+            </result>
+            XML
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $rows = $connector->metadata()->list();
+
+    $mockClient->assertSent(function (CallSqlRequest $request): bool {
+        $sql = $request->query()->get('action');
+
+        return str_starts_with($sql, 'SELECT TABLE_NAME, FIELD_NAME, PROMPT, DATA_TYPE FROM DPFIELDS')
+            && str_contains($sql, "TABLE_NAME IN ('DP','DPGIFT')");
+    });
+
+    expect($rows)->toHaveCount(2)
+        ->and($rows[0])->toMatchArray([
+            'table_name' => 'DP',
+            'field_name' => 'PRONOUN_UDF',
+            'prompt' => 'Pronoun',
+            'data_type' => 'C',
+        ])
+        ->and($rows[1]['table_name'])->toBe('DPGIFT');
+});
+
+it('lets the caller scope to a single table', function () {
+    $mockClient = new MockClient([
+        CallSqlRequest::class => MockResponse::make('<?xml version="1.0"?><result/>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->metadata()->list(['DPGIFT']);
+
+    $mockClient->assertSent(function (CallSqlRequest $request): bool {
+        return str_contains($request->query()->get('action'), "TABLE_NAME IN ('DPGIFT')");
+    });
+});
+
+it('rejects unknown table names', function () {
+    (new DonorPerfect('k'))->metadata()->list(['DROP_TABLE']);
+})->throws(InvalidDataException::class);

--- a/tests/Unit/Resources/UdfResourceTest.php
+++ b/tests/Unit/Resources/UdfResourceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\InvalidDataException;
+use DonorPerfect\Requests\Udf\SaveUdf;
+use DonorPerfect\Resources\UdfResource;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('exposes a udfs() accessor on the connector', function () {
+    expect((new DonorPerfect('k'))->udfs())->toBeInstanceOf(UdfResource::class);
+});
+
+it('builds a dp_save_udf_xml call with @matching_id, @field_name, @data_type, @field_value', function () {
+    $mockClient = new MockClient([
+        SaveUdf::class => MockResponse::make('<?xml version="1.0"?><result><record><field name="success" value="true"/></record></result>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->udfs()->save(12345, 'PRONOUN_UDF', 'C', 'they/them');
+
+    $mockClient->assertSent(function (SaveUdf $request): bool {
+        $action = $request->query()->get('action');
+        $params = $request->query()->get('params');
+
+        return $action === 'dp_save_udf_xml'
+            && str_contains($params, '@matching_id=12345')
+            && str_contains($params, "@field_name='PRONOUN_UDF'")
+            && str_contains($params, "@data_type='C'")
+            && str_contains($params, "@field_value='they/them'");
+    });
+});
+
+it('serializes a null UDF value as null (not the literal string "null")', function () {
+    $mockClient = new MockClient([
+        SaveUdf::class => MockResponse::make('<?xml version="1.0"?><result/>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->udfs()->save(12345, 'PRONOUN_UDF', 'C', null);
+
+    $mockClient->assertSent(function (SaveUdf $request): bool {
+        return str_contains($request->query()->get('params'), '@field_value=null');
+    });
+});
+
+it('throws InvalidDataException for an unsupported data_type', function () {
+    (new DonorPerfect('k'))->udfs()->save(1, 'F', 'X', 'v');
+})->throws(InvalidDataException::class);
+
+it('accepts every documented DPFIELDS data_type', function (string $dataType) {
+    $mockClient = new MockClient([
+        SaveUdf::class => MockResponse::make('<?xml version="1.0"?><result/>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->udfs()->save(1, 'F', $dataType, 'v');
+
+    $mockClient->assertSent(function (SaveUdf $request) use ($dataType): bool {
+        return str_contains($request->query()->get('params'), "@data_type='{$dataType}'");
+    });
+})->with(['C', 'D', 'M', 'N']);

--- a/tests/Unit/Support/ActionParamsTest.php
+++ b/tests/Unit/Support/ActionParamsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use DonorPerfect\Support\ActionParams;
+
+it('serializes a string value with single quotes', function () {
+    expect(ActionParams::serialize(['field_name' => 'CAMPAIGN']))
+        ->toBe("@field_name='CAMPAIGN'");
+});
+
+it('serializes a numeric value without quotes', function () {
+    expect(ActionParams::serialize(['matching_id' => 12345]))
+        ->toBe('@matching_id=12345');
+});
+
+it('serializes a null value as bare null (not the string "null")', function () {
+    expect(ActionParams::serialize(['field_value' => null]))
+        ->toBe('@field_value=null');
+});
+
+it('joins multiple params with ", " preserving insertion order', function () {
+    expect(ActionParams::serialize([
+        'matching_id' => 12345,
+        'field_name' => 'PRONOUN',
+        'data_type' => 'C',
+        'field_value' => 'they',
+    ]))->toBe("@matching_id=12345, @field_name='PRONOUN', @data_type='C', @field_value='they'");
+});
+
+it('returns an empty string for an empty property bag', function () {
+    expect(ActionParams::serialize([]))->toBe('');
+});
+
+it('treats numeric strings as numeric (DP backwards-compat)', function () {
+    expect(ActionParams::serialize(['amount' => '100.50']))
+        ->toBe('@amount=100.50');
+});


### PR DESCRIPTION
- Adds four new resources to the SDK so consumers can read DonorPerfect's `dpcodes` and `DPFIELDS` tables and write UDF values and donor flags.                                      

                                                                
  | Resource | Purpose |                                                                                                                                                             
  |---|---|                                                                        
  | `CodeResource` | Read `dpcodes` rows for a given `field_name` |
  | `MetadataResource` | Read `DPFIELDS` (UDF schema) for given table names |
  | `UdfResource` | Write a UDF value to a donor or gift |
  | `FlagResource` | Apply a flag to a donor (additive only) |                                                                                                                       
                                                                                                                                                                                     

-   Internally, all four DP action requests now share a single `Support\ActionParams` helper for serializing the `@key=value` param string DonorPerfect expects.                       

                                                                                                                                                                                     
  ## Backward compatibility                                                        
                                                                                                                                                                                     

-   Purely additive. No existing public method, signature, base URL, header, or authenticator changed. `SaveDonor` and `SaveGift` were refactored onto the new helper but their on-the-wire output is byte-identical, pinned by tests.                                                                                                                             
                                                                                                                                                                                     

-   Recommend tagging as **v0.3.0** (minor) after merge.  