### PR TITLE
Surface DonorPerfect API errors instead of swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to `betterworldcollective/donorperfect-php-sdk` will be documented in this file.
+
+## [0.3.2] — 2026-05-11
+
+### Changed — silent failures now throw
+
+The SDK previously swallowed DonorPerfect error and malformed responses, returning `0` from
+`saveDonor()`/`saveGift()` and an empty `array` from `UdfResource::save()`/`FlagResource::save()`.
+Callers had no way to distinguish "DP rejected the call" from "the call succeeded with id 0".
+
+These methods now throw `DonorPerfect\Exceptions\DonorPerfectException` when DP returns an empty body,
+malformed XML, or a body without the expected `<record>` element. The exception message includes the
+raw response body for diagnosis.
+
+- `DonorPerfect::saveDonor()` — throws on missing `<record>` or missing `field[value]`
+- `DonorPerfect::saveGift()` — same pattern
+- `Resources\UdfResource::save()` — throws on empty/malformed XML
+- `Resources\FlagResource::save()` — throws on empty/malformed XML
+
+### Added
+
+- `DonorPerfect\Exceptions\DonorPerfectException` — base exception for DP-rejected calls
+- Optional PSR-3 logger injection via `new DonorPerfect($apiKey, $logger)`. Defaults to `NullLogger`.
+  `testConnection()` keeps its `bool` return contract but now logs the underlying exception via the
+  injected logger before returning `false` (silent failure was the bug).
+- Explicit `psr/log` requirement in `composer.json` (was previously transitive via Saloon).
+
+### Fixed
+
+- `Responses\DonorPerfectResponse::xml()` no longer emits PHP `E_WARNING` on malformed XML.
+  libxml errors are now suppressed via `libxml_use_internal_errors()` and surfaced via the existing
+  `false` return value.
+
+### Migration notes
+
+Callers of `saveDonor`, `saveGift`, `UdfResource::save`, and `FlagResource::save` that previously
+relied on `0`/`[]` as a "failed silently" signal must now handle `DonorPerfectException`. Inside
+`bw-api`, `DonorPerfectDriver::create()` already wraps SDK calls in `try/catch (Exception $e)` and
+re-throws as `CRMException`, so no behavior change is needed at that layer — exceptions bubble
+correctly into the existing `rescue()` in `SyncModelToCRMJob` and report to Bugsnag.

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
     "name": "betterworldcollective/donorperfect-php-sdk",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "require": {
         "php": "^8.2",
         "saloonphp/saloon": "^4.0",
         "illuminate/collections": "^11.0.8 | ^12.7",
-        "illuminate/support": "^11.0.8 | ^12.7"
+        "illuminate/support": "^11.0.8 | ^12.7",
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.22",

--- a/src/DonorPerfect.php
+++ b/src/DonorPerfect.php
@@ -3,6 +3,7 @@
 namespace DonorPerfect;
 
 use DonorPerfect\Authentications\DonorPerfectToken;
+use DonorPerfect\Exceptions\DonorPerfectException;
 use DonorPerfect\Requests\CallSqlRequest;
 use DonorPerfect\Requests\Donor\SaveDonor;
 use DonorPerfect\Requests\Gift\SaveGift;
@@ -13,6 +14,8 @@ use DonorPerfect\Resources\MetadataResource;
 use DonorPerfect\Resources\UdfResource;
 use DonorPerfect\Responses\DonorPerfectResponse;
 use Exception;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Saloon\Contracts\Authenticator;
 use Saloon\Http\Connector;
 use Saloon\Http\Response;
@@ -51,6 +54,11 @@ class DonorPerfect extends Connector
     public string $apiKey;
 
     /**
+     * Logger used to surface non-throwing failures (e.g. testConnection).
+     */
+    private LoggerInterface $logger;
+
+    /**
      * Define the custom response
      *
      * @var class-string<Response>|null
@@ -60,10 +68,16 @@ class DonorPerfect extends Connector
     /**
      * Constructor
      */
-    public function __construct(string $apiKey)
+    public function __construct(string $apiKey, ?LoggerInterface $logger = null)
     {
         // URL decode the API key to prevent double-encoding when used as query parameter
         $this->apiKey = urldecode($apiKey);
+        $this->logger = $logger ?? new NullLogger;
+    }
+
+    public function getLogger(): LoggerInterface
+    {
+        return $this->logger;
     }
 
     /**
@@ -128,6 +142,10 @@ class DonorPerfect extends Connector
 
             return true;
         } catch (Exception $e) {
+            $this->logger->error('DonorPerfect testConnection failed: '.$e->getMessage(), [
+                'exception' => $e,
+            ]);
+
             return false;
         }
     }
@@ -177,45 +195,53 @@ class DonorPerfect extends Connector
 
     /**
      * Save donor using saveDonor
-     */
-    /**
+     *
      * @param  array<string, mixed>  $data
+     *
+     * @throws DonorPerfectException when DP returns an error or malformed response
      */
     public function saveDonor(array $data): int
     {
         $request = new SaveDonor($data);
         $response = $this->send($request);
+        $body = $response->body();
         $xml = $response->xml();
-        if ($xml instanceof SimpleXMLElement && isset($xml->record)) {
-            // Extract the donor_id from the record field
-            $record = $xml->record;
-            if (isset($record->field) && isset($record->field['value'])) {
-                return (int) $record->field['value'];
-            }
+
+        if (! $xml instanceof SimpleXMLElement || ! isset($xml->record)) {
+            throw new DonorPerfectException('DonorPerfect rejected SaveDonor: '.$body);
         }
 
-        return 0;
+        $record = $xml->record;
+        if (! isset($record->field) || ! isset($record->field['value'])) {
+            throw new DonorPerfectException('DonorPerfect SaveDonor returned unexpected response: '.$body);
+        }
+
+        return (int) $record->field['value'];
     }
 
     /**
      * Save gift using saveGift
-     */
-    /**
+     *
      * @param  array<string, mixed>  $data
+     *
+     * @throws DonorPerfectException when DP returns an error or malformed response
      */
     public function saveGift(array $data): int
     {
         $request = new SaveGift($data);
         $response = $this->send($request);
+        $body = $response->body();
         $xml = $response->xml();
-        if ($xml instanceof SimpleXMLElement && isset($xml->record)) {
-            // Extract the gift_id from the record field
-            $record = $xml->record;
-            if (isset($record->field) && isset($record->field['value'])) {
-                return (int) $record->field['value'];
-            }
+
+        if (! $xml instanceof SimpleXMLElement || ! isset($xml->record)) {
+            throw new DonorPerfectException('DonorPerfect rejected SaveGift: '.$body);
         }
 
-        return 0;
+        $record = $xml->record;
+        if (! isset($record->field) || ! isset($record->field['value'])) {
+            throw new DonorPerfectException('DonorPerfect SaveGift returned unexpected response: '.$body);
+        }
+
+        return (int) $record->field['value'];
     }
 }

--- a/src/Exceptions/DonorPerfectException.php
+++ b/src/Exceptions/DonorPerfectException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DonorPerfect\Exceptions;
+
+use Exception;
+
+class DonorPerfectException extends Exception {}

--- a/src/Resources/FlagResource.php
+++ b/src/Resources/FlagResource.php
@@ -4,6 +4,7 @@ namespace DonorPerfect\Resources;
 
 use DateTimeInterface;
 use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\DonorPerfectException;
 use DonorPerfect\Requests\Flag\SaveFlag;
 use Saloon\Http\BaseResource;
 
@@ -17,6 +18,8 @@ class FlagResource extends BaseResource
      * exposed by this SDK to prevent accidental data loss in sync listeners.
      *
      * @return array<string, mixed>
+     *
+     * @throws DonorPerfectException when DP returns an empty or malformed response
      */
     public function save(int $donorId, string $flagCode, ?DateTimeInterface $flagDate = null): array
     {
@@ -33,6 +36,10 @@ class FlagResource extends BaseResource
         }
 
         $response = $connector->send(new SaveFlag($properties));
+
+        if ($response->xml() === false) {
+            throw new DonorPerfectException('DonorPerfect rejected SaveFlag: '.$response->body());
+        }
 
         return $response->xmlArray();
     }

--- a/src/Resources/UdfResource.php
+++ b/src/Resources/UdfResource.php
@@ -3,6 +3,7 @@
 namespace DonorPerfect\Resources;
 
 use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\DonorPerfectException;
 use DonorPerfect\Exceptions\InvalidDataException;
 use DonorPerfect\Requests\Udf\SaveUdf;
 use Saloon\Http\BaseResource;
@@ -20,6 +21,7 @@ class UdfResource extends BaseResource
      * @return array<string, mixed>
      *
      * @throws InvalidDataException when $dataType is not one of C/D/M/N
+     * @throws DonorPerfectException when DP returns an empty or malformed response
      */
     public function save(int $matchingId, string $fieldName, string $dataType, ?string $value): array
     {
@@ -36,6 +38,10 @@ class UdfResource extends BaseResource
             'data_type' => $dataType,
             'field_value' => $value,
         ]));
+
+        if ($response->xml() === false) {
+            throw new DonorPerfectException('DonorPerfect rejected SaveUdf: '.$response->body());
+        }
 
         return $response->xmlArray();
     }

--- a/src/Responses/DonorPerfectResponse.php
+++ b/src/Responses/DonorPerfectResponse.php
@@ -16,11 +16,22 @@ class DonorPerfectResponse extends Response
             return false;
         }
 
-        return simplexml_load_string($body);
+        // libxml emits PHP warnings on malformed XML by default. Surface the failure
+        // via the bool return value instead so callers (and tests) stay clean.
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $xml = simplexml_load_string($body);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        return $xml;
     }
 
     /**
      * Get the response as array from XML
+     *
      * @return array<string, mixed>
      */
     public function xmlArray(): array
@@ -36,7 +47,7 @@ class DonorPerfectResponse extends Response
         }
 
         $result = json_decode($jsonString, true);
-        if (!is_array($result)) {
+        if (! is_array($result)) {
             return [];
         }
 

--- a/tests/Unit/Resources/FlagResourceTest.php
+++ b/tests/Unit/Resources/FlagResourceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\DonorPerfectException;
 use DonorPerfect\Requests\Flag\SaveFlag;
 use DonorPerfect\Resources\FlagResource;
 use Saloon\Http\Faking\MockClient;
@@ -49,4 +50,31 @@ it('omits @flag_date when none is provided so DP defaults to today', function ()
     $mockClient->assertSent(function (SaveFlag $request): bool {
         return ! str_contains($request->query()->get('params'), '@flag_date');
     });
+});
+
+it('throws DonorPerfectException when DP returns an empty body', function () {
+    $mockClient = new MockClient([
+        SaveFlag::class => MockResponse::make(''),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->flags()->save(1, 'WEB');
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveFlag');
+
+it('throws DonorPerfectException when DP returns malformed XML', function () {
+    $mockClient = new MockClient([
+        SaveFlag::class => MockResponse::make('not xml at all'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->flags()->save(1, 'WEB');
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveFlag');
+
+it('returns the parsed array on a valid response', function () {
+    $mockClient = new MockClient([
+        SaveFlag::class => MockResponse::make('<?xml version="1.0"?><result><record><field name="success" value="true"/></record></result>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->flags()->save(1, 'WEB'))->toBeArray();
 });

--- a/tests/Unit/Resources/UdfResourceTest.php
+++ b/tests/Unit/Resources/UdfResourceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\DonorPerfectException;
 use DonorPerfect\Exceptions\InvalidDataException;
 use DonorPerfect\Requests\Udf\SaveUdf;
 use DonorPerfect\Resources\UdfResource;
@@ -34,3 +35,30 @@ it('builds a dp_save_udf_xml call with @matching_id, @field_name, @data_type, @f
 it('throws InvalidDataException for an unsupported data_type', function () {
     (new DonorPerfect('k'))->udfs()->save(1, 'F', 'X', 'v');
 })->throws(InvalidDataException::class);
+
+it('throws DonorPerfectException when DP returns an empty body', function () {
+    $mockClient = new MockClient([
+        SaveUdf::class => MockResponse::make(''),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->udfs()->save(1, 'PRONOUN_UDF', 'C', 'they/them');
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveUdf');
+
+it('throws DonorPerfectException when DP returns malformed XML', function () {
+    $mockClient = new MockClient([
+        SaveUdf::class => MockResponse::make('not xml at all'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->udfs()->save(1, 'PRONOUN_UDF', 'C', 'they/them');
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveUdf');
+
+it('returns the parsed array on a valid response', function () {
+    $mockClient = new MockClient([
+        SaveUdf::class => MockResponse::make('<?xml version="1.0"?><result><record><field name="success" value="true"/></record></result>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->udfs()->save(1, 'PRONOUN_UDF', 'C', 'they/them'))->toBeArray();
+});

--- a/tests/Unit/SaveDonorTest.php
+++ b/tests/Unit/SaveDonorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\DonorPerfectException;
+use DonorPerfect\Requests\Donor\SaveDonor;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('returns the donor_id from a valid SaveDonor response', function () {
+    $mockClient = new MockClient([
+        SaveDonor::class => MockResponse::make(
+            '<?xml version="1.0"?><result><record><field name="donor_id" value="987654"/></record></result>'
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->saveDonor(['first_name' => 'Test']))->toBe(987654);
+});
+
+it('throws DonorPerfectException when the response body is empty', function () {
+    $mockClient = new MockClient([
+        SaveDonor::class => MockResponse::make(''),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->saveDonor(['first_name' => 'Test']);
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveDonor');
+
+it('throws DonorPerfectException when DP returns an error body without a <record>', function () {
+    $mockClient = new MockClient([
+        SaveDonor::class => MockResponse::make(
+            '<?xml version="1.0"?><result><error>Some DP error</error></result>'
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->saveDonor(['first_name' => 'Test']);
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveDonor');
+
+it('throws DonorPerfectException when <record> exists but the value attribute is missing', function () {
+    $mockClient = new MockClient([
+        SaveDonor::class => MockResponse::make(
+            '<?xml version="1.0"?><result><record><field name="donor_id"/></record></result>'
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->saveDonor(['first_name' => 'Test']);
+})->throws(DonorPerfectException::class, 'unexpected response');

--- a/tests/Unit/SaveGiftTest.php
+++ b/tests/Unit/SaveGiftTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Exceptions\DonorPerfectException;
+use DonorPerfect\Requests\Gift\SaveGift;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('returns the gift_id from a valid SaveGift response', function () {
+    $mockClient = new MockClient([
+        SaveGift::class => MockResponse::make(
+            '<?xml version="1.0"?><result><record><field name="gift_id" value="555111"/></record></result>'
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->saveGift(['donor_id' => 1, 'amount' => 100]))->toBe(555111);
+});
+
+it('throws DonorPerfectException when the response body is empty', function () {
+    $mockClient = new MockClient([
+        SaveGift::class => MockResponse::make(''),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->saveGift(['donor_id' => 1, 'amount' => 100]);
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveGift');
+
+it('throws DonorPerfectException when DP returns an error body without a <record>', function () {
+    $mockClient = new MockClient([
+        SaveGift::class => MockResponse::make(
+            '<?xml version="1.0"?><result><error>Some DP error</error></result>'
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->saveGift(['donor_id' => 1, 'amount' => 100]);
+})->throws(DonorPerfectException::class, 'DonorPerfect rejected SaveGift');
+
+it('throws DonorPerfectException when <record> exists but the value attribute is missing', function () {
+    $mockClient = new MockClient([
+        SaveGift::class => MockResponse::make(
+            '<?xml version="1.0"?><result><record><field name="gift_id"/></record></result>'
+        ),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    $connector->saveGift(['donor_id' => 1, 'amount' => 100]);
+})->throws(DonorPerfectException::class, 'unexpected response');

--- a/tests/Unit/TestConnectionTest.php
+++ b/tests/Unit/TestConnectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use DonorPerfect\DonorPerfect;
+use DonorPerfect\Requests\TestConnection;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+/**
+ * Build an in-test PSR-3 logger spy that records every call. Avoids pulling
+ * in a mocking library just to assert on log writes.
+ */
+function spyLogger(): object
+{
+    return new class extends AbstractLogger
+    {
+        /** @var list<array{level:mixed, message:string, context:array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, $message, array $context = []): void
+        {
+            $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+        }
+    };
+}
+
+it('returns true when DP responds with a record', function () {
+    $mockClient = new MockClient([
+        TestConnection::class => MockResponse::make('<?xml version="1.0"?><result><record>ok</record></result>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->testConnection())->toBeTrue();
+});
+
+it('returns false when DP responds with success=false', function () {
+    $mockClient = new MockClient([
+        TestConnection::class => MockResponse::make('<?xml version="1.0"?><result><field name="success" value="false"/></result>'),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->testConnection())->toBeFalse();
+});
+
+it('returns false and logs the exception when the request throws', function () {
+    $logger = spyLogger();
+
+    $mockClient = new MockClient([
+        TestConnection::class => MockResponse::make('Server exploded', 500),
+    ]);
+    $connector = (new DonorPerfect('k', $logger))->withMockClient($mockClient);
+
+    expect($connector->testConnection())->toBeFalse();
+    expect($logger->records)->toHaveCount(1);
+    expect($logger->records[0]['message'])->toContain('DonorPerfect testConnection failed');
+});
+
+it('defaults to NullLogger when no logger is supplied', function () {
+    $mockClient = new MockClient([
+        TestConnection::class => MockResponse::make('Server exploded', 500),
+    ]);
+    $connector = (new DonorPerfect('k'))->withMockClient($mockClient);
+
+    expect($connector->testConnection())->toBeFalse();
+    expect($connector->getLogger())->toBeInstanceOf(NullLogger::class);
+});


### PR DESCRIPTION
## Summary

`saveDonor`, `saveGift`, `UdfResource::save`, and `FlagResource::save` previously returned `0` or `[]` when DonorPerfect rejected a call, leaving callers no way to distinguish failure from a real id-zero / empty response. They now throw `DonorPerfectException` with the raw DP body in the message.

`testConnection()` keeps its `bool` contract but now logs the underlying exception via an injected PSR-3 logger before returning `false`. The constructor accepts an optional `LoggerInterface` (defaults to `NullLogger`); bw-api will pass Laravel's logger so failures land in Bugsnag.

Also fixes `Responses\DonorPerfectResponse::xml()` emitting PHP `E_WARNING` on malformed XML — same silent-failure shape, surfaced via `libxml_use_internal_errors()`.

## Why

Diagnosed against prod org 133443 / Talbert House: 4 sync attempts on 2026-05-06 all returned `crm_id=0` with nothing in Bugsnag. The SDK was hiding DP's actual rejection reason.

## Test plan

- [x] Pest: 43 tests / 87 assertions pass
- [x] Pint clean
- [x] PHPStan clean
- [ ] Tag and publish v0.3.2 (handled by reviewer)
- [ ] Bump constraint in bw-api to ^0.3.2 (separate PR)

## Notes for reviewer

Backwards-incompatible behavior change for callers that relied on `0`/`[]` as a "swallowed failure" sentinel. Inside bw-api, `DonorPerfectDriver::create()` already wraps SDK calls in `catch (Exception)` → `CRMException`, so exceptions bubble correctly into the existing `rescue()` in `SyncModelToCRMJob` and report to Bugsnag. No bw-api logic change required beyond the version bump and passing the logger.