### PR TITLE
Allow FLAGS field_name in CodeResource (v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `betterworldcollective/donorperfect-php-sdk` will be documented in this file.
 
+## [0.3.3] — 2026-05-12
+
+### Added
+
+- `'FLAGS'` added to `Resources\CodeResource::ALLOWED_FIELD_NAMES`. Callers can now run `$client->codes()->list('FLAGS')` to fetch the org's `dpcodes` rows where `FIELD_NAME='FLAGS'`. Previously rejected with `InvalidDataException`. Enables the donor-flags dropdown in BetterWorld's DP integration dashboard.
+
+### Backward compatibility
+
+Purely additive — no existing call site changes behavior. The allowlist only grows.
+
 ## [0.3.2] — 2026-05-11
 
 ### Changed — silent failures now throw

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "betterworldcollective/donorperfect-php-sdk",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "require": {
         "php": "^8.2",
         "saloonphp/saloon": "^4.0",

--- a/src/Resources/CodeResource.php
+++ b/src/Resources/CodeResource.php
@@ -17,6 +17,7 @@ class CodeResource extends BaseResource
         'EMAIL_TYPE',
         'PHONE_TYPE',
         'ADDRESS_TYPE',
+        'FLAGS',
     ];
 
     /**

--- a/tests/Unit/Resources/CodeResourceTest.php
+++ b/tests/Unit/Resources/CodeResourceTest.php
@@ -77,3 +77,36 @@ it('throws InvalidDataException for an unknown field_name', function () {
 
     $connector->codes()->list("CAMPAIGN'; DROP TABLE dpcodes; --");
 })->throws(InvalidDataException::class);
+
+it('accepts FLAGS as a valid field_name and queries dpcodes', function () {
+    $mockClient = new MockClient([
+        CallSqlRequest::class => MockResponse::make(
+            <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <result>
+                <record>
+                    <field name="CODE" value="WEB"/>
+                    <field name="DESCRIPTION" value="Online donor"/>
+                    <field name="INACTIVE" value="0"/>
+                </record>
+            </result>
+            XML
+        ),
+    ]);
+
+    $connector = new DonorPerfect('test-api-key');
+    $connector->withMockClient($mockClient);
+
+    $rows = $connector->codes()->list('FLAGS');
+
+    $mockClient->assertSent(function (CallSqlRequest $request): bool {
+        return $request->resolveEndpoint() === '/xmlrequest.asp';
+    });
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0])->toMatchArray([
+            'code' => 'WEB',
+            'description' => 'Online donor',
+            'inactive' => false,
+        ]);
+});


### PR DESCRIPTION
## Summary

Adds `'FLAGS'` to `Resources\CodeResource::ALLOWED_FIELD_NAMES`. Callers can now run `\$client->codes()->list('FLAGS')` to fetch the org's `dpcodes` rows where `FIELD_NAME='FLAGS'`. Previously rejected with `InvalidDataException` before any SQL was sent.

## Why

bw-api's DonorPerfect integration (Ticket DEV-3895, in progress) needs the donor-flags dropdown — admins pick which DP flags to apply to every synced donor. The dashboard fetches the available flags from DP via `dpcodes` exactly the same way it fetches CAMPAIGN / GL_CODE / SOLICIT / etc. Same `dpcodes` SQL, same `CodeResource` shape — only the allowlist needs the new entry.

In hindsight this could have been bundled into v0.3.2 (the error-handling hotfix) since they would have shipped together. Filing as v0.3.3 instead keeps each release single-purpose.

## Test plan

- [x] Pest: 44 tests / 95 assertions pass (1 new test exercises FLAGS happy path)
- [x] Pint clean
- [x] PHPStan clean
- [ ] Tag + publish v0.3.3 (handled by reviewer)
- [ ] Bump constraint in bw-api to ^0.3.3 (separate PR / part of DEV-3895)

## Backward compatibility

Purely additive — the allowlist only grows. No existing call site changes behavior.