### PR TITLE
Update CodeResource.php to detect Y as an inactivity marker

### DIFF
--- a/src/Resources/CodeResource.php
+++ b/src/Resources/CodeResource.php
@@ -76,7 +76,7 @@ class CodeResource extends BaseResource
                     $row['description'] = $value === '' ? null : $value;
                     break;
                 case 'INACTIVE':
-                    $row['inactive'] = $value === '1' || strcasecmp($value, 'true') === 0;
+                    $row['inactive'] = $value === '1' || $value == 'Y' || strcasecmp($value, 'true') === 0;
                     break;
             }
         }


### PR DESCRIPTION
This change will treat a value of 'Y' in the inactive field as marking that the Code should have active: 0, since the "Y" value seems to either be the initial DP default and/or set by the DP UI.